### PR TITLE
Removed "Total Spent" card from the Bookings page

### DIFF
--- a/web/src/app/(main)/bookings/bookings-list.tsx
+++ b/web/src/app/(main)/bookings/bookings-list.tsx
@@ -316,7 +316,7 @@ export function BookingsList({ initialBookings }: BookingsListProps) {
       )}
 
       {/* Stats Cards */}
-      <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-4 mb-8">
+      <div className="grid grid-cols-1 md:grid-cols-3 xl:grid-cols-3 gap-4 mb-8">
         <Card className="p-4 bg-gradient-to-br from-blue-50 to-blue-100 border-blue-200">
           <div className="flex items-center gap-3">
             <div className="w-12 h-12 bg-blue-500 rounded-lg flex items-center justify-center">
@@ -358,24 +358,7 @@ export function BookingsList({ initialBookings }: BookingsListProps) {
             </div>
           </div>
         </Card>
-
-        <Card className="p-4 bg-gradient-to-br from-purple-50 to-purple-100 border-purple-200">
-          <div className="flex items-center gap-3">
-            <div className="w-12 h-12 bg-purple-500 rounded-lg flex items-center justify-center">
-              <svg className="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-              </svg>
-            </div>
-            <div>
-              <p className="text-sm text-purple-700 font-medium">Total Spent</p>
-              <p className="text-2xl font-bold text-purple-900">
-                ₱{bookings.reduce((sum, b) => sum + b.total_amount, 0).toFixed(0)}
-              </p>
-            </div>
-          </div>
-        </Card>
       </div>
-
       {/* Bookings List */}
       {filteredBookings.length === 0 ? (
         <Card className="p-12 text-center">


### PR DESCRIPTION
Total Spent card has been removed from the Bookings page, and the other cards have been arranged so that they fit neatly on the bookings page

FILE MODIFIED: web/src/app/(main)/bookings/bookings-list.tsx

ACTIONS TAKEN:
Removed "Total Spent" card

SCREENSHOT:
<img width="1366" height="582" alt="Screenshot_20260208_224408" src="https://github.com/user-attachments/assets/74f3eb7c-6185-4732-aa3c-9cdc40288f07" />

